### PR TITLE
Make build type set to release if it's not specified as debug.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ option(DEBUG "Enable debugging" OFF)
 if(${DEBUG})
     message(STATUS "Enabling debugging")
     set(CMAKE_BUILD_TYPE Debug)
+else()
+    set(CMAKE_BUILD_TYPE Release)
 endif()
 
 option(ENABLE_C_ABI "Enable C ABI" OFF)


### PR DESCRIPTION
Libraries built without this statement were set to "Debug" automatically, what could lead to crashes when someone didn't have required debugging programs installed.