### PR TITLE
Fix UE compilation errors. Add new functions to Access Manager.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,9 +61,9 @@ FetchContent_MakeAvailable(pubnub)
 
 # TODO: this flag is okay until we release the Cpp-Chat as an independent library
 if(${ENABLE_C_ABI})
-    target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unity/0.1.3\")
+    target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unity/0.3.1\")
 else()
-    target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unreal/0.2.3\")
+    target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unreal/0.2.4\")
 endif()
 
 FetchContent_Declare(

--- a/c_abi/include/c_chat.hpp
+++ b/c_abi/include/c_chat.hpp
@@ -194,4 +194,10 @@ PN_CHAT_EXTERN PN_CHAT_EXPORT Pubnub::User* pn_chat_current_user(Pubnub::Chat* c
 
 PN_CHAT_EXTERN PN_CHAT_EXPORT PnCTribool pn_pam_can_i(Pubnub::Chat* chat, Pubnub::AccessManager::Permission permission, Pubnub::AccessManager::ResourceType resource_type, const char* resource_name);
 
+PN_CHAT_EXTERN PN_CHAT_EXPORT PnCResult pn_pam_parse_token(Pubnub::Chat* chat, const char* token, char* result);
+
+PN_CHAT_EXTERN PN_CHAT_EXPORT PnCResult pn_pam_set_auth_token(Pubnub::Chat* chat, const char* token);
+
+PN_CHAT_EXTERN PN_CHAT_EXPORT PnCResult pn_pam_set_pubnub_origin(Pubnub::Chat* chat, const char* origin);
+
 #endif // PN_CHAT_C_CHAT_HPP

--- a/c_abi/src/c_chat.cpp
+++ b/c_abi/src/c_chat.cpp
@@ -833,7 +833,45 @@ PnCTribool pn_pam_can_i(Pubnub::Chat *chat, Pubnub::AccessManager::Permission pe
     }
 }
 
+PnCResult pn_pam_parse_token(Pubnub::Chat* chat, const char* token, char* result) {
+    try {
+        auto parsed = chat->access_manager().parse_token(token);
+        strcpy(result, parsed.c_str());
+    }
+    catch (std::exception& e) {
+        pn_c_set_error_message(e.what());
 
+        return PN_C_ERROR;
+    }
+
+    return PN_C_OK;
+}
+
+PnCResult pn_pam_set_auth_token(Pubnub::Chat* chat, const char* token) {
+    try {
+        chat->access_manager().set_auth_token(token);
+    }
+    catch (std::exception& e) {
+        pn_c_set_error_message(e.what());
+
+        return PN_C_ERROR;
+    }
+
+    return PN_C_OK;
+}
+
+PnCResult pn_pam_set_pubnub_origin(Pubnub::Chat* chat, const char* origin) {
+    try {
+        chat->access_manager().set_pubnub_origin(origin);
+    }
+    catch (std::exception& e) {
+        pn_c_set_error_message(e.what());
+
+        return PN_C_ERROR;
+    }
+
+    return PN_C_OK;
+}
 
 
 

--- a/include/pubnub_chat/access_manager.hpp
+++ b/include/pubnub_chat/access_manager.hpp
@@ -22,6 +22,10 @@ namespace Pubnub {
 
 
         PN_CHAT_EXPORT bool can_i(AccessManager::Permission permission, AccessManager::ResourceType resource_type, const Pubnub::String& resource_name) const; 
+        
+        PN_CHAT_EXPORT Pubnub::String parse_token(const Pubnub::String token) const;
+        PN_CHAT_EXPORT void set_auth_token(const Pubnub::String token) const;
+        PN_CHAT_EXPORT int set_pubnub_origin(const Pubnub::String origin) const;
 
         private:
         AccessManager(std::shared_ptr<const AccessManagerService> access_manager_service);

--- a/include/pubnub_chat/channel.hpp
+++ b/include/pubnub_chat/channel.hpp
@@ -66,61 +66,61 @@ namespace Pubnub
         Pubnub::String status;
     };
 
-    class Channel {
+    class PN_CHAT_EXPORT Channel {
         public:
-            PN_CHAT_EXPORT Channel();
-            PN_CHAT_EXPORT Channel(const Channel& other);
-            PN_CHAT_EXPORT ~Channel();
+            Channel();
+            Channel(const Channel& other);
+            virtual ~Channel();
 
-            PN_CHAT_EXPORT Pubnub::Channel& operator =(const Pubnub::Channel& other);
+            Pubnub::Channel& operator =(const Pubnub::Channel& other);
 
-            PN_CHAT_EXPORT Pubnub::String channel_id() const;
-            PN_CHAT_EXPORT Pubnub::ChatChannelData channel_data() const;
+            Pubnub::String channel_id() const;
+            Pubnub::ChatChannelData channel_data() const;
 
-            PN_CHAT_EXPORT Pubnub::Channel update(const ChatChannelData& in_additional_channel_data) const;
+            Pubnub::Channel update(const ChatChannelData& in_additional_channel_data) const;
 #ifndef PN_CHAT_C_ABI
-            PN_CHAT_EXPORT void connect(std::function<void(Message)> message_callback) const;
-            PN_CHAT_EXPORT void join(std::function<void(Message)> message_callback, const Pubnub::String& additional_params = "") const;
-            PN_CHAT_EXPORT void disconnect() const;
-            PN_CHAT_EXPORT void leave() const;
+            void connect(std::function<void(Message)> message_callback) const;
+            void join(std::function<void(Message)> message_callback, const Pubnub::String& additional_params = "") const;
+            void disconnect() const;
+            void leave() const;
 #endif
-            PN_CHAT_EXPORT void delete_channel() const;
+            void delete_channel() const;
 
-            PN_CHAT_EXPORT virtual void send_text(const Pubnub::String& message, SendTextParams text_params = SendTextParams());
-            PN_CHAT_EXPORT Pubnub::Vector<Pubnub::String> who_is_present() const;
-            PN_CHAT_EXPORT bool is_present(const Pubnub::String& user_id) const;
-            PN_CHAT_EXPORT void set_restrictions(const Pubnub::String& user_id, Pubnub::Restriction restrictions) const;
-            PN_CHAT_EXPORT Pubnub::Restriction get_user_restrictions(const Pubnub::User& user) const;
-            PN_CHAT_EXPORT UsersRestrictionsWrapper get_users_restrictions(const Pubnub::String& sort = "", int limit = 0, const Pubnub::Page& page = Pubnub::Page()) const;
-            PN_CHAT_EXPORT Pubnub::Vector<Pubnub::Message> get_history(const Pubnub::String& start_timetoken, const Pubnub::String& end_timetoken, int count = 25) const;
-            PN_CHAT_EXPORT Pubnub::Message get_message(const Pubnub::String& timetoken) const;
-            PN_CHAT_EXPORT MembersResponseWrapper get_members(const Pubnub::String& filter = "", const Pubnub::String& sort = "", int limit = 0, const Pubnub::Page& page = Pubnub::Page()) const;
-            PN_CHAT_EXPORT Pubnub::Membership invite(const Pubnub::User& user) const;
-            PN_CHAT_EXPORT Pubnub::Vector<Pubnub::Membership> invite_multiple(Pubnub::Vector<Pubnub::User> users) const;
-            PN_CHAT_EXPORT void start_typing() const;
-            PN_CHAT_EXPORT void stop_typing() const;
-            PN_CHAT_EXPORT CallbackStop get_typing(std::function<void(Pubnub::Vector<Pubnub::String>)> typing_callback) const;
-            PN_CHAT_EXPORT Pubnub::Channel pin_message(const Pubnub::Message& message) const;
-            PN_CHAT_EXPORT Pubnub::Channel unpin_message() const;
-            PN_CHAT_EXPORT Pubnub::Message get_pinned_message() const;
-            PN_CHAT_EXPORT void forward_message(const Pubnub::Message& message) const;
-            PN_CHAT_EXPORT virtual void emit_user_mention(const Pubnub::String& user_id, const Pubnub::String& timetoken, const Pubnub::String& text) const;
-            PN_CHAT_EXPORT Pubnub::Vector<Pubnub::Membership> get_user_suggestions(Pubnub::String text, int limit = 10) const;
+            virtual void send_text(const Pubnub::String& message, SendTextParams text_params = SendTextParams());
+            Pubnub::Vector<Pubnub::String> who_is_present() const;
+            bool is_present(const Pubnub::String& user_id) const;
+            void set_restrictions(const Pubnub::String& user_id, Pubnub::Restriction restrictions) const;
+            Pubnub::Restriction get_user_restrictions(const Pubnub::User& user) const;
+            UsersRestrictionsWrapper get_users_restrictions(const Pubnub::String& sort = "", int limit = 0, const Pubnub::Page& page = Pubnub::Page()) const;
+            Pubnub::Vector<Pubnub::Message> get_history(const Pubnub::String& start_timetoken, const Pubnub::String& end_timetoken, int count = 25) const;
+            Pubnub::Message get_message(const Pubnub::String& timetoken) const;
+            MembersResponseWrapper get_members(const Pubnub::String& filter = "", const Pubnub::String& sort = "", int limit = 0, const Pubnub::Page& page = Pubnub::Page()) const;
+            Pubnub::Membership invite(const Pubnub::User& user) const;
+            Pubnub::Vector<Pubnub::Membership> invite_multiple(Pubnub::Vector<Pubnub::User> users) const;
+            void start_typing() const;
+            void stop_typing() const;
+            CallbackStop get_typing(std::function<void(Pubnub::Vector<Pubnub::String>)> typing_callback) const;
+            Pubnub::Channel pin_message(const Pubnub::Message& message) const;
+            Pubnub::Channel unpin_message() const;
+            Pubnub::Message get_pinned_message() const;
+            void forward_message(const Pubnub::Message& message) const;
+            virtual void emit_user_mention(const Pubnub::String& user_id, const Pubnub::String& timetoken, const Pubnub::String& text) const;
+            Pubnub::Vector<Pubnub::Membership> get_user_suggestions(Pubnub::String text, int limit = 10) const;
 
-            PN_CHAT_EXPORT CallbackStop stream_updates(std::function<void(const Pubnub::Channel&)> channel_callback) const;
-            PN_CHAT_EXPORT CallbackStop stream_updates_on(Pubnub::Vector<Pubnub::Channel> channels, std::function<void(Pubnub::Vector<Pubnub::Channel>)> channel_callback);
-            PN_CHAT_EXPORT CallbackStop stream_presence(std::function<void(Pubnub::Vector<Pubnub::String>)> presence_callback) const;
-            PN_CHAT_EXPORT CallbackStop stream_read_receipts(std::function<void(Pubnub::Map<Pubnub::String, Pubnub::Vector<Pubnub::String>, Pubnub::StringComparer>)> read_receipts_callback) const;
+            CallbackStop stream_updates(std::function<void(const Pubnub::Channel&)> channel_callback) const;
+            CallbackStop stream_updates_on(Pubnub::Vector<Pubnub::Channel> channels, std::function<void(Pubnub::Vector<Pubnub::Channel>)> channel_callback);
+            CallbackStop stream_presence(std::function<void(Pubnub::Vector<Pubnub::String>)> presence_callback) const;
+            CallbackStop stream_read_receipts(std::function<void(Pubnub::Map<Pubnub::String, Pubnub::Vector<Pubnub::String>, Pubnub::StringComparer>)> read_receipts_callback) const;
 
-            PN_CHAT_EXPORT Pubnub::EventsHistoryWrapper get_messsage_reports_history(const Pubnub::String& start_timetoken, const Pubnub::String& end_timetoken, int count = 100) const;
+            Pubnub::EventsHistoryWrapper get_messsage_reports_history(const Pubnub::String& start_timetoken, const Pubnub::String& end_timetoken, int count = 100) const;
 #ifndef PN_CHAT_C_ABI
-            PN_CHAT_EXPORT CallbackStop stream_message_reports(std::function<void(const Pubnub::Event&)> event_callback) const;
+            CallbackStop stream_message_reports(std::function<void(const Pubnub::Event&)> event_callback) const;
 #endif
 
-            PN_CHAT_EXPORT Pubnub::MessageDraft create_message_draft(Pubnub::MessageDraftConfig message_draft_config = Pubnub::MessageDraftConfig()) const;
+            Pubnub::MessageDraft create_message_draft(Pubnub::MessageDraftConfig message_draft_config = Pubnub::MessageDraftConfig()) const;
 
         protected:
-            PN_CHAT_EXPORT Channel(
+            Channel(
                     Pubnub::String channel_id,
                     std::shared_ptr<const ChatService> chat_service,
                     std::shared_ptr<const ChannelService> channel_service,

--- a/include/pubnub_chat/helpers/export.hpp
+++ b/include/pubnub_chat/helpers/export.hpp
@@ -39,6 +39,8 @@
 #    define PN_CHAT_NO_DEPRECATED
 #  endif
 #endif
+#else
+#  define PN_CHAT_EXPORT
 #endif
 
 #endif /* PN_CHAT_EXPORT_HPP */

--- a/include/pubnub_chat/helpers/export.hpp
+++ b/include/pubnub_chat/helpers/export.hpp
@@ -2,9 +2,43 @@
 #define PN_CHAT_EXPORT_HPP
 
 #if defined(_WIN32) || defined(__WIN32__) || defined(__WINDOWS__) || defined(__MINGW32__)
-#define PN_CHAT_EXPORT __declspec(dllexport)
+#ifdef PN_CHAT_STATIC_DEFINE
+#  define PN_CHAT_EXPORT
+#  define PN_CHAT_NO_EXPORT
 #else
-#define PN_CHAT_EXPORT
+#  ifndef PN_CHAT_EXPORT
+#    ifdef pubnub_chat_EXPORTS
+        /* We are building this library */
+#      define PN_CHAT_EXPORT __declspec(dllexport)
+#    else
+        /* We are using this library */
+#      define PN_CHAT_EXPORT __declspec(dllimport)
+#    endif
+#  endif
+
+#  ifndef PN_CHAT_NO_EXPORT
+#    define PN_CHAT_NO_EXPORT 
+#  endif
+#endif
+
+#ifndef PN_CHAT_DEPRECATED
+#  define PN_CHAT_DEPRECATED __declspec(deprecated)
+#endif
+
+#ifndef PN_CHAT_DEPRECATED_EXPORT
+#  define PN_CHAT_DEPRECATED_EXPORT PN_CHAT_EXPORT PN_CHAT_DEPRECATED
+#endif
+
+#ifndef PN_CHAT_DEPRECATED_NO_EXPORT
+#  define PN_CHAT_DEPRECATED_NO_EXPORT PN_CHAT_NO_EXPORT PN_CHAT_DEPRECATED
+#endif
+
+/* NOLINTNEXTLINE(readability-avoid-unconditional-preprocessor-if) */
+#if 0 /* DEFINE_NO_DEPRECATED */
+#  ifndef PN_CHAT_NO_DEPRECATED
+#    define PN_CHAT_NO_DEPRECATED
+#  endif
+#endif
 #endif
 
 #endif /* PN_CHAT_EXPORT_HPP */

--- a/include/pubnub_chat/thread_channel.hpp
+++ b/include/pubnub_chat/thread_channel.hpp
@@ -17,8 +17,8 @@ namespace Pubnub
         PN_CHAT_EXPORT ThreadChannel();
         PN_CHAT_EXPORT ThreadChannel& operator=(const ThreadChannel& other);
 
-        PN_CHAT_EXPORT Pubnub::String parent_channel_id() const {return parent_channel_id_internal;};
-        PN_CHAT_EXPORT Pubnub::Message parent_message() const {return parent_message_internal;};
+        PN_CHAT_EXPORT Pubnub::String parent_channel_id() const;
+        PN_CHAT_EXPORT Pubnub::Message parent_message() const;
 
         PN_CHAT_EXPORT void send_text(const Pubnub::String& message, SendTextParams text_params = SendTextParams()) override;
 

--- a/include/pubnub_chat/thread_message.hpp
+++ b/include/pubnub_chat/thread_message.hpp
@@ -15,7 +15,7 @@ namespace Pubnub
     class ThreadMessage : public Message
     {
         public:
-        PN_CHAT_EXPORT ~ThreadMessage();
+        PN_CHAT_EXPORT virtual ~ThreadMessage();
         PN_CHAT_EXPORT ThreadMessage& operator=(const ThreadMessage& other);
 
         PN_CHAT_EXPORT Pubnub::String parent_channel_id() const {return parent_channel_id_internal;};

--- a/src/application/access_manager_service.cpp
+++ b/src/application/access_manager_service.cpp
@@ -31,3 +31,21 @@ bool AccessManagerService::can_i(Pubnub::AccessManager::Permission permission, P
 
     return AccessManagerLogic::can_i(permission, resource_type, json_token, resource_name);
 }
+
+Pubnub::String AccessManagerService::parse_token(const Pubnub::String auth_key) const 
+{
+    auto pubnub_handle = this->pubnub->lock();
+    return pubnub_handle->parse_token(auth_key);
+}
+
+void AccessManagerService::set_auth_token(const Pubnub::String token) const
+{
+    auto pubnub_handle = this->pubnub->lock();
+    pubnub_handle->set_auth_token(token);
+}
+
+int AccessManagerService::set_pubnub_origin(const Pubnub::String origin) const
+{
+    auto pubnub_handle = this->pubnub->lock();
+    return pubnub_handle->set_pubnub_origin(origin);
+}

--- a/src/application/access_manager_service.hpp
+++ b/src/application/access_manager_service.hpp
@@ -13,6 +13,10 @@ class AccessManagerService {
 
         bool can_i(Pubnub::AccessManager::Permission permission, Pubnub::AccessManager::ResourceType resource_type, const Pubnub::String& resource_name) const; 
 
+        Pubnub::String parse_token(const Pubnub::String auth_key) const;
+        void set_auth_token(const Pubnub::String token) const;
+        int set_pubnub_origin(const Pubnub::String origin) const;
+
     private:
         Pubnub::String auth_key;
         ThreadSafePtr<PubNub> pubnub;

--- a/src/infra/pubnub.cpp
+++ b/src/infra/pubnub.cpp
@@ -46,8 +46,8 @@ PubNub::PubNub(const Pubnub::String publish_key, const Pubnub::String subscribe_
     pubnub_set_non_blocking_io(this->long_poll_context.get());
 
     if (!auth_key.empty()) {
-        pubnub_set_auth(this->main_context.get(), this->auth_key.c_str());
-        pubnub_set_auth(this->long_poll_context.get(), this->auth_key.c_str());
+        pubnub_set_auth_token(this->main_context.get(), this->auth_key.c_str());
+        pubnub_set_auth_token(this->long_poll_context.get(), this->auth_key.c_str());
     }
 }
 
@@ -758,10 +758,13 @@ Pubnub::String PubNub::parse_token(const Pubnub::String auth_key)
 
 void PubNub::set_auth_token(const Pubnub::String token) 
 {
-    pubnub_set_auth_token(this->main_context.get(), token.c_str());
+    auth_key = token;
+    pubnub_set_auth_token(this->main_context.get(), auth_key.c_str());
+    pubnub_set_auth_token(this->long_poll_context.get(), auth_key.c_str());
 }
 
 int PubNub::set_pubnub_origin(const Pubnub::String origin) 
 {
     return pubnub_origin_set(this->main_context.get(), origin.c_str());
+    return pubnub_origin_set(this->long_poll_context.get(), origin.c_str());
 }

--- a/src/infra/pubnub.cpp
+++ b/src/infra/pubnub.cpp
@@ -765,6 +765,7 @@ void PubNub::set_auth_token(const Pubnub::String token)
 
 int PubNub::set_pubnub_origin(const Pubnub::String origin) 
 {
-    return pubnub_origin_set(this->main_context.get(), origin.c_str());
-    return pubnub_origin_set(this->long_poll_context.get(), origin.c_str());
+    custom_origin = origin;
+    return pubnub_origin_set(this->main_context.get(), custom_origin.c_str());
+    return pubnub_origin_set(this->long_poll_context.get(), custom_origin.c_str());
 }

--- a/src/infra/pubnub.cpp
+++ b/src/infra/pubnub.cpp
@@ -755,3 +755,13 @@ Pubnub::String PubNub::parse_token(const Pubnub::String auth_key)
 {
     return pubnub_parse_token(this->main_context.get(), auth_key.c_str());
 }
+
+void PubNub::set_auth_token(const Pubnub::String token) 
+{
+    pubnub_set_auth_token(this->main_context.get(), token.c_str());
+}
+
+int PubNub::set_pubnub_origin(const Pubnub::String origin) 
+{
+    return pubnub_origin_set(this->main_context.get(), origin.c_str());
+}

--- a/src/infra/pubnub.hpp
+++ b/src/infra/pubnub.hpp
@@ -84,6 +84,7 @@ private:
     Pubnub::String subscribe_key;
     Pubnub::String user_id;
     Pubnub::String auth_key;
+    Pubnub::String custom_origin;
 
     std::unique_ptr<pubnub_t, int(*)(pubnub_t*)> main_context;
     std::unique_ptr<pubnub_t, int(*)(pubnub_t*)> long_poll_context;

--- a/src/infra/pubnub.hpp
+++ b/src/infra/pubnub.hpp
@@ -67,7 +67,9 @@ public:
     std::map<Pubnub::String, int, Pubnub::StringComparer> message_counts(const std::vector<Pubnub::String> channels, const std::vector<Pubnub::String> timestamps);
     bool delete_messages(const Pubnub::String channel, const Pubnub::String start, const Pubnub::String end);
     
-    Pubnub::String parse_token(const Pubnub::String auth_key) ;
+    Pubnub::String parse_token(const Pubnub::String auth_key);
+    void set_auth_token(const Pubnub::String token);
+    int set_pubnub_origin(const Pubnub::String origin);
 
 private:
     void await_and_handle_error(pubnub_res result);

--- a/src/presentation/access_manager.cpp
+++ b/src/presentation/access_manager.cpp
@@ -25,3 +25,18 @@ bool Pubnub::AccessManager::can_i(Pubnub::AccessManager::Permission permission, 
 {
     return this->access_manager_service->can_i(permission, resource_type, resource_name);
 }
+
+Pubnub::String Pubnub::AccessManager::parse_token(const Pubnub::String token) const
+{
+    return this->access_manager_service->parse_token(token);
+}
+
+void Pubnub::AccessManager::set_auth_token(const Pubnub::String token) const
+{
+    this->access_manager_service->set_auth_token(token);
+}
+
+int Pubnub::AccessManager::set_pubnub_origin(const Pubnub::String origin) const
+{
+    return this->access_manager_service->set_pubnub_origin(origin);
+}

--- a/src/presentation/thread_channel.cpp
+++ b/src/presentation/thread_channel.cpp
@@ -52,6 +52,16 @@ ThreadChannel::ThreadChannel() :
 
 ThreadChannel::~ThreadChannel() = default;
 
+Pubnub::String Pubnub::ThreadChannel::parent_channel_id() const
+{
+    return parent_channel_id_internal;
+}
+
+Pubnub::Message Pubnub::ThreadChannel::parent_message() const
+{
+    return parent_message_internal;
+}
+
 void ThreadChannel::send_text(const String &message, SendTextParams text_params)
 {
     //If this is new thread, set all server data before sending the first message (this is actually creating the thread, even if the object was created earlier)


### PR DESCRIPTION
add(PAM): add new functions to Access Manager

Add following functions to Access Manager: `parse_token`, `set_auth_token`, `set_pubnub_origin`

fix(ue): fix `thread_channel `related errors when using cpp chat in Unreal Engine

fix(channel): fix non-virtual destructor in `channel`
