### PR TITLE
Add Linux support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,13 @@ option(RUN_TESTS "Run tests" OFF)
 
 option(COMPILE_EXAMPLES "Compile examples" OFF)
 
+#Unreal Engine on Linux uses libc++ insted of libstdc++. This is required to build it correctly for UE (requires libc++ to be installed)
+option(LINUX_FOR_UNREAL "Using Linux for Unreal Engine" OFF)
+if(${LINUX_FOR_UNREAL})
+   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -nostdinc++ -I/usr/include/c++/v1")
+   set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib/llvm-14/lib -Wl,-rpath,/usr/lib/llvm-14/lib -lc++ -lc++abi")
+endif()
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/include/pubnub_chat)
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/src) # not public imports
@@ -63,7 +70,7 @@ FetchContent_MakeAvailable(pubnub)
 if(${ENABLE_C_ABI})
     target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unity/0.3.1\")
 else()
-    target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unreal/0.2.4\")
+    target_compile_options(pubnub PUBLIC -DPUBNUB_SDK_VERSION_SUFFIX=\"/CA-Unreal/0.2.5\")
 endif()
 
 FetchContent_Declare(

--- a/include/pubnub_chat/enums.hpp
+++ b/include/pubnub_chat/enums.hpp
@@ -2,6 +2,7 @@
 #define PN_ENUMS_HPP
 
 #include "string.hpp"
+#include <cstdint>
 
 namespace Pubnub
 {

--- a/include/pubnub_chat/message_draft.hpp
+++ b/include/pubnub_chat/message_draft.hpp
@@ -4,6 +4,7 @@
 #include "string.hpp"
 #include <map>
 #include <vector>
+#include <functional>
 
 #include "option.hpp"
 #include "message_elements.hpp"


### PR DESCRIPTION
fix(build): fix compilation errors when trying to build cpp chat on Linux

add(cmake): add CMake flag to enable required compilation flags when building for Unreal Engine on Linux