### PR TITLE
Fix bug with Access Manager not using the newest set Auth Token

### DIFF
--- a/src/application/access_manager_service.hpp
+++ b/src/application/access_manager_service.hpp
@@ -9,7 +9,7 @@
 
 class AccessManagerService {
     public:
-        AccessManagerService(ThreadSafePtr<PubNub> pubnub, Pubnub::String auth_key);
+        AccessManagerService(ThreadSafePtr<PubNub> pubnub);
 
         bool can_i(Pubnub::AccessManager::Permission permission, Pubnub::AccessManager::ResourceType resource_type, const Pubnub::String& resource_name) const; 
 
@@ -18,7 +18,6 @@ class AccessManagerService {
         int set_pubnub_origin(const Pubnub::String origin) const;
 
     private:
-        Pubnub::String auth_key;
         ThreadSafePtr<PubNub> pubnub;
 };
 

--- a/src/application/chat_service.cpp
+++ b/src/application/chat_service.cpp
@@ -42,7 +42,7 @@ void ChatService::init_services(const ChatConfig& config) {
     membership_service = std::make_shared<MembershipService>(pubnub, weak_from_this());
     presence_service = std::make_shared<PresenceService>(pubnub, weak_from_this());
     restrictions_service = std::make_shared<RestrictionsService>(pubnub, weak_from_this());
-    access_manager_service = std::make_shared<AccessManagerService>(pubnub, config.auth_key);
+    access_manager_service = std::make_shared<AccessManagerService>(pubnub);
     this->chat_config = config;
 #ifndef PN_CHAT_C_ABI
     auto service_bundle = EntityServicesBundle{

--- a/src/infra/pubnub.cpp
+++ b/src/infra/pubnub.cpp
@@ -756,6 +756,11 @@ Pubnub::String PubNub::parse_token(const Pubnub::String auth_key)
     return pubnub_parse_token(this->main_context.get(), auth_key.c_str());
 }
 
+Pubnub::String PubNub::get_current_auth_token() 
+{
+    return this->auth_key;
+}
+
 void PubNub::set_auth_token(const Pubnub::String token) 
 {
     auth_key = token;

--- a/src/infra/pubnub.hpp
+++ b/src/infra/pubnub.hpp
@@ -68,6 +68,7 @@ public:
     bool delete_messages(const Pubnub::String channel, const Pubnub::String start, const Pubnub::String end);
     
     Pubnub::String parse_token(const Pubnub::String auth_key);
+    Pubnub::String get_current_auth_token();
     void set_auth_token(const Pubnub::String token);
     int set_pubnub_origin(const Pubnub::String origin);
 


### PR DESCRIPTION
fix(access_manager): Fix bug with Access Manager not using the newest set Auth Token

There could be a case that someone `init_chat` with an `auth_key` and then use `set_auth_token`. Newly set token wouldn't be used in `can_i` function from the `Access Manager`.

Also `auth_key` was stored in `Pubnub.cpp` and `AccessManagerService`. Now it's only in `Pubnub.cpp`