### PR TITLE
Add Membership status and type

### DIFF
--- a/include/pubnub_chat/membership.hpp
+++ b/include/pubnub_chat/membership.hpp
@@ -19,6 +19,13 @@ namespace Pubnub
 {
     class Message;
 
+    struct ChatMembershipData
+    {
+        Pubnub::String custom_data_json = "";
+        Pubnub::String status = "";
+        Pubnub::String type = "";
+    };
+
     PN_CHAT_EXPORT class Membership
     {
         public:
@@ -30,9 +37,13 @@ namespace Pubnub
 
             PN_CHAT_EXPORT Pubnub::Membership& operator =(const Pubnub::Membership& other);
 
+            //TODO:: Mark as deprecated
             PN_CHAT_EXPORT Pubnub::String custom_data() const;
+            PN_CHAT_EXPORT Pubnub::ChatMembershipData membership_data() const;
 
+            //TODO:: Mark as deprecated
             PN_CHAT_EXPORT Pubnub::Membership update(const Pubnub::String& custom_object_json) const;
+            PN_CHAT_EXPORT Pubnub::Membership update(const Pubnub::ChatMembershipData& membership_data) const;
             PN_CHAT_EXPORT Pubnub::String last_read_message_timetoken() const;
             PN_CHAT_EXPORT Pubnub::Membership set_last_read_message_timetoken(const Pubnub::String& timetoken) const;
             PN_CHAT_EXPORT Pubnub::Membership set_last_read_message(const Pubnub::Message& message) const;

--- a/include/pubnub_chat/membership.hpp
+++ b/include/pubnub_chat/membership.hpp
@@ -37,11 +37,11 @@ namespace Pubnub
 
             PN_CHAT_EXPORT Pubnub::Membership& operator =(const Pubnub::Membership& other);
 
-            //TODO:: Mark as deprecated
+            [[deprecated("Replaced by membership_data() which contains more membership information")]]
             PN_CHAT_EXPORT Pubnub::String custom_data() const;
             PN_CHAT_EXPORT Pubnub::ChatMembershipData membership_data() const;
 
-            //TODO:: Mark as deprecated
+            //TODO:: Mark as deprecated??
             PN_CHAT_EXPORT Pubnub::Membership update(const Pubnub::String& custom_object_json) const;
             PN_CHAT_EXPORT Pubnub::Membership update(const Pubnub::ChatMembershipData& membership_data) const;
             PN_CHAT_EXPORT Pubnub::String last_read_message_timetoken() const;

--- a/src/application/callback_service.cpp
+++ b/src/application/callback_service.cpp
@@ -579,8 +579,8 @@ CCoreCallbackData CallbackService::to_c_memberships_updates_callback(const std::
                             custom_field
                     );
 
-                    MembershipEntity stream_membership_entity = MembershipDAO(stream_membership->custom_data()).to_entity();
-                    MembershipEntity membership_entity = MembershipDAO(membership_obj.custom_data()).to_entity();
+                    MembershipEntity stream_membership_entity = MembershipDAO(stream_membership->membership_data()).to_entity();
+                    MembershipEntity membership_entity = MembershipDAO(membership_obj.membership_data()).to_entity();
                     auto updated_membership = chat->membership_service->create_membership_object(stream_membership->user, stream_membership->channel, MembershipEntity::from_base_and_updated_membership(stream_membership_entity, membership_entity));
 
                     std::vector<Pubnub::Membership> updated_memberships;

--- a/src/application/channel_service.cpp
+++ b/src/application/channel_service.cpp
@@ -60,7 +60,7 @@ std::tuple<Channel, Membership, std::vector<Membership>> ChannelService::create_
         auto pubnub_handle = this->pubnub->lock();
 
         //TODO: Add filter when it will be supported in C-Core
-        String include_string = "custom,channel,totalCount,customChannel";
+        String include_string = "custom,channel,totalCount,channel.custom";
         user_id = pubnub_handle->get_user_id();
         pubnub_handle->set_memberships(pubnub_handle->get_user_id(), create_set_memberships_object(final_channel_id), include_string);
     }
@@ -90,7 +90,7 @@ std::tuple<Channel, Membership, std::vector<Membership>> ChannelService::create_
         user_id = pubnub_handle->get_user_id();
 
         //TODO: Add filter when it will be supported in C-Core
-        String include_string = "custom,channel,totalCount,customChannel";
+        String include_string = "custom,channel,totalCount,custom.channel";
         String memberships_response = pubnub_handle->set_memberships(user_id, create_set_memberships_object(final_channel_id), include_string);
     }
 

--- a/src/application/dao/membership_dao.cpp
+++ b/src/application/dao/membership_dao.cpp
@@ -1,8 +1,8 @@
 #include "membership_dao.hpp"
 #include "domain/membership_entity.hpp"
 
-MembershipDAO::MembershipDAO(const Pubnub::String& custom_data) :
-    entity({custom_data})
+MembershipDAO::MembershipDAO(const Pubnub::ChatMembershipData& membership_data) :
+    entity(entity_from_membership_data(membership_data))
 {}
 
 MembershipDAO::MembershipDAO(const MembershipEntity& entity) :
@@ -17,7 +17,20 @@ const MembershipEntity& MembershipDAO::get_entity() const {
     return this->entity;
 }
 
-Pubnub::String MembershipDAO::to_custom_data() const {
-    return this->entity.custom_field;
+Pubnub::ChatMembershipData MembershipDAO::to_membership_data() const {
+    Pubnub::ChatMembershipData membership_data;
+    membership_data.custom_data_json = this->entity.custom_field;
+    membership_data.status = this->entity.status;
+    membership_data.type = this->entity.type;
+
+    return membership_data;
 }
 
+MembershipEntity MembershipDAO::entity_from_membership_data(const Pubnub::ChatMembershipData& membership_data){
+    MembershipEntity entity;
+    entity.custom_field = membership_data.custom_data_json;
+    entity.status = membership_data.status;
+    entity.type = membership_data.type;
+
+    return entity;
+}

--- a/src/application/dao/membership_dao.hpp
+++ b/src/application/dao/membership_dao.hpp
@@ -6,15 +6,17 @@
 
 class MembershipDAO {
     public:
-        MembershipDAO(const Pubnub::String& custom_data);
+        MembershipDAO(const Pubnub::ChatMembershipData& membership_data);
         MembershipDAO(const MembershipEntity& entity);
         ~MembershipDAO() = default;
 
-        Pubnub::String to_custom_data() const;
+        Pubnub::ChatMembershipData to_membership_data() const;
         const MembershipEntity& get_entity() const;
         MembershipEntity to_entity() const;
 
     private:
+        static MembershipEntity entity_from_membership_data(const Pubnub::ChatMembershipData& membership_data);
+
         MembershipEntity entity;
 };
 

--- a/src/application/membership_service.cpp
+++ b/src/application/membership_service.cpp
@@ -34,7 +34,7 @@ std::tuple<std::vector<Pubnub::Membership>, Pubnub::Page, int, Pubnub::String> M
         throw std::invalid_argument("can't get members, limit has to be within 0 - " + std::to_string(PN_MAX_LIMIT) + " range");
     }
 
-    String include_string = "custom,channel,totalCount,customChannel";
+    String include_string = "custom,channel,totalCount,channel.custom,status,type";
 
     auto get_channel_members_response = [this, channel_id, include_string, limit, filter, sort, page] {
         auto pubnub_handle = this->pubnub->lock();
@@ -81,7 +81,7 @@ std::tuple<std::vector<Pubnub::Membership>, Pubnub::Page, int, Pubnub::String> M
         throw std::invalid_argument("can't get memberships, limit has to be within 0 - " + std::to_string(PN_MAX_LIMIT) + " range");
     }
 
-    String include_string = "totalCount,custom,channel,customChannel,channelType,status,channelStatus";
+    String include_string = "totalCount,custom,channel,channel.custom,type,channel.type,status,channel.status";
 
     auto get_memberships_response = [this, user_id, include_string, filter, sort,  limit, page] {
         auto pubnub_handle = this->pubnub->lock();
@@ -138,7 +138,7 @@ Membership MembershipService::invite_to_channel(const String& channel_id, const 
         return members[0];
     }
 
-    String include_string = "custom,channel,totalCount,customChannel";
+    String include_string = "custom,channel,totalCount,channel.custom,status,type";
     String set_memeberships_obj = create_set_memberships_object(channel_id, "");
 
     auto user_id = user.user_id();
@@ -181,7 +181,7 @@ std::vector<Membership> MembershipService::invite_multiple_to_channel(const Stri
         }
     }
 
-    String include_string = "custom,channel,totalCount,customChannel";
+    String include_string = "custom,channel,totalCount,channel.custom,status,type";
     String set_memebers_obj = create_set_members_object(users_ids, "");
 
     auto set_members_response = [this, channel_id, set_memebers_obj, include_string, filter] {
@@ -380,7 +380,7 @@ std::tuple<Pubnub::Page, int, int, std::vector<Pubnub::Membership>> MembershipSe
 
     auto memberships_response = [this, current_user, set_memberships_string] {
         auto pubnub_handle = pubnub->lock();
-        String include_string = "custom,channel,totalCount,customChannel";
+        String include_string = "custom,channel,totalCount,custom.channel,status,type";
         return pubnub_handle->set_memberships(current_user.user_id(), set_memberships_string, include_string);
     }();
 

--- a/src/application/membership_service.cpp
+++ b/src/application/membership_service.cpp
@@ -215,9 +215,11 @@ std::vector<Membership> MembershipService::invite_multiple_to_channel(const Stri
     return invitees_memberships;
 }
 
-Membership MembershipService::update(const User& user, const Channel& channel, const String& custom_object_json) const {
+Membership MembershipService::update(const User& user, const Channel& channel, MembershipDAO membership_data) const {
+    auto entity = membership_data.to_entity();
+
     String custom_object_json_string;
-    custom_object_json.empty() ? custom_object_json_string = "{}" : custom_object_json_string = custom_object_json;
+    entity.custom_field.empty() ? custom_object_json_string = "{}" : custom_object_json_string = entity.custom_field;
 
     json response_json = json::parse(custom_object_json_string);
     
@@ -226,18 +228,16 @@ Membership MembershipService::update(const User& user, const Channel& channel, c
         throw std::invalid_argument("Can't update membership, custom_object_json is not valid json object");
     }
 
-	String set_memberships_string = String("[{\"channel\": {\"id\": \"") + channel.channel_id() + String("\"}, \"custom\": ") + custom_object_json_string + String("}]");
-
     {
         auto pubnub_handle = pubnub->lock();
-        pubnub_handle->set_memberships(user.user_id(), set_memberships_string);
+        pubnub_handle->set_memberships(user.user_id(), entity.get_set_memberships_json_string(channel.channel_id()));
     }
 
-    return create_membership_object(user, channel, create_domain_membership(custom_object_json_string));
+    return create_membership_object(user, channel, entity);
 }
 
 String MembershipService::last_read_message_timetoken(const Membership& membership) const {
-    String custom_data = membership.custom_data();
+    String custom_data = membership.membership_data().custom_data_json;
     if(custom_data.empty())
     {
         return String();
@@ -250,7 +250,7 @@ String MembershipService::last_read_message_timetoken(const Membership& membersh
 
 Pubnub::Membership MembershipService::set_last_read_message_timetoken(const Membership& membership, const String& timetoken) const {
     
-    String custom_data = membership.custom_data().empty() ? "{}" : membership.custom_data();
+    String custom_data = membership.membership_data().custom_data_json.empty() ? "{}" : membership.membership_data().custom_data_json;
 
     Json custom_data_json = Json::parse(custom_data);
     custom_data_json.insert_or_update("lastReadMessageTimetoken", timetoken);
@@ -360,7 +360,7 @@ std::tuple<Pubnub::Page, int, int, std::vector<Pubnub::Membership>> MembershipSe
     {
         relevant_channel_ids.push_back(membership.channel.channel_id());
         
-        String custom_object_json_string = membership.custom_data().empty() ? String("{}") : membership.custom_data();
+        String custom_object_json_string = membership.membership_data().custom_data_json.empty() ? String("{}") : membership.membership_data().custom_data_json;
         json custom_object_json = json::parse(custom_object_json_string);
         custom_object_json["lastReadMessageTimetoken"] = now_timetoken.c_str();
 
@@ -479,16 +479,9 @@ Membership MembershipService::create_membership_object(const User& user, const C
     throw std::runtime_error("Can't create membership, chat service pointer is invalid");
 }
 
-MembershipEntity MembershipService::create_domain_membership(const String& custom_object_json) const {
-    MembershipEntity new_membership_entity;
-    new_membership_entity.custom_field = custom_object_json;
-    return new_membership_entity;
-    
-}
-
 Pubnub::Membership MembershipService::update_membership_with_base(const Pubnub::Membership& membership, const Pubnub::Membership& base_membership) const {
-        MembershipEntity base_entity = MembershipDAO(base_membership.custom_data()).to_entity();
-        MembershipEntity membership_entity = MembershipDAO(membership.custom_data()).to_entity();
+        MembershipEntity base_entity = MembershipDAO(base_membership.membership_data()).to_entity();
+        MembershipEntity membership_entity = MembershipDAO(membership.membership_data()).to_entity();
 
         return create_membership_object(
                 base_membership.user,

--- a/src/application/membership_service.hpp
+++ b/src/application/membership_service.hpp
@@ -28,7 +28,7 @@ class MembershipService : public std::enable_shared_from_this<MembershipService>
         Pubnub::Membership invite_to_channel(const Pubnub::String& channel_id, const ChannelDAO& channel_data, const Pubnub::User& user) const;
         std::vector<Pubnub::Membership> invite_multiple_to_channel(const Pubnub::String& channel_id, const ChannelDAO& channel_data, const std::vector<Pubnub::User>& users) const;
     
-        Pubnub::Membership update(const Pubnub::User& user, const Pubnub::Channel& channel, const Pubnub::String& custom_object_json) const;
+        Pubnub::Membership update(const Pubnub::User& user, const Pubnub::Channel& channel, MembershipDAO membership_data) const;
         Pubnub::String last_read_message_timetoken(const Pubnub::Membership& membership) const;
         Pubnub::Membership set_last_read_message_timetoken(const Pubnub::Membership& membership, const Pubnub::String& timetoken) const;
         int get_unread_messages_count_one_channel(const Pubnub::Membership& membership) const;

--- a/src/domain/membership_entity.cpp
+++ b/src/domain/membership_entity.cpp
@@ -24,7 +24,7 @@ Pubnub::String MembershipEntity::get_set_memberships_json_string(Pubnub::String 
         set_memberships_json.insert_or_update("type", type);
     }
 
-    return set_memberships_json.dump();
+    return Pubnub::String("[" + set_memberships_json.dump() + "]");
 }
 
 MembershipEntity MembershipEntity::from_json(Json membership_json) {

--- a/src/domain/membership_entity.cpp
+++ b/src/domain/membership_entity.cpp
@@ -1,8 +1,37 @@
 #include "membership_entity.hpp"
+#include "domain/json.hpp"
+
+Pubnub::String MembershipEntity::get_set_memberships_json_string(Pubnub::String channel_id){
+    Json channel_json;
+    channel_json.insert_or_update("id", channel_id);
+
+    Json set_memberships_json;
+
+    set_memberships_json.insert_or_update("channel", channel_json);
+
+    if(!custom_field.empty()) {
+        Json custom_json = Json::parse(custom_field);
+        set_memberships_json.insert_or_update("custom", custom_json);
+    }
+    else 
+    {
+        set_memberships_json.insert_or_update("custom", "{}");
+    }
+    if(!status.empty()) {
+        set_memberships_json.insert_or_update("status", status);
+    }
+    if(!type.empty()) {
+        set_memberships_json.insert_or_update("type", type);
+    }
+
+    return set_memberships_json.dump();
+}
 
 MembershipEntity MembershipEntity::from_json(Json membership_json) {
     return MembershipEntity{
-        membership_json.contains("custom") ? membership_json["custom"].dump() : Pubnub::String("")
+        membership_json.contains("custom") ? membership_json["custom"].dump() : Pubnub::String(""),
+        membership_json.get_string("status").value_or(Pubnub::String("")),
+        membership_json.get_string("type").value_or(Pubnub::String(""))
     };
 }
 
@@ -10,5 +39,7 @@ MembershipEntity MembershipEntity::from_base_and_updated_membership(MembershipEn
 {
     MembershipEntity new_entity;
     new_entity.custom_field = updated_membership.custom_field.empty() ? base_membership.custom_field : updated_membership.custom_field;
+    new_entity.status = updated_membership.status.empty() ? base_membership.status : updated_membership.status;
+    new_entity.type = updated_membership.type.empty() ? base_membership.type : updated_membership.type;
     return new_entity;
 }

--- a/src/domain/membership_entity.hpp
+++ b/src/domain/membership_entity.hpp
@@ -6,9 +6,9 @@
 #include "membership.hpp"
 
 struct MembershipEntity {
-    Pubnub::String custom_field;
-    Pubnub::String status;
-    Pubnub::String type;
+    Pubnub::String custom_field = "";
+    Pubnub::String status = "";
+    Pubnub::String type = "";
 
     Pubnub::String get_set_memberships_json_string(Pubnub::String channel_id);
 

--- a/src/domain/membership_entity.hpp
+++ b/src/domain/membership_entity.hpp
@@ -7,10 +7,14 @@
 
 struct MembershipEntity {
     Pubnub::String custom_field;
+    Pubnub::String status;
+    Pubnub::String type;
+
+    Pubnub::String get_set_memberships_json_string(Pubnub::String channel_id);
 
     static MembershipEntity from_json(Json membership_json);
-
     static MembershipEntity from_base_and_updated_membership(MembershipEntity base_membership, MembershipEntity updated_membership);
+
 };
 
 #endif // PN_CHAT_MEMBERSHIP_ENTITY_HPP

--- a/src/presentation/membership.cpp
+++ b/src/presentation/membership.cpp
@@ -19,7 +19,7 @@ user(other.user),
 channel(other.channel),
 chat_service(other.chat_service),
 membership_service(other.membership_service),
-data(std::make_unique<MembershipDAO>(other.data->to_custom_data()))
+data(std::make_unique<MembershipDAO>(other.data->to_membership_data()))
 {}
 
 Membership& Membership::operator =(const Membership& other)
@@ -30,7 +30,7 @@ Membership& Membership::operator =(const Membership& other)
     }
     this->user = other.user;
     this->channel = other.channel;
-    this->data = std::make_unique<::MembershipDAO>(other.data->to_custom_data());
+    this->data = std::make_unique<::MembershipDAO>(other.data->to_membership_data());
     this->chat_service = other.chat_service;
     this->membership_service = other.membership_service;
 
@@ -40,11 +40,19 @@ Membership& Membership::operator =(const Membership& other)
 Membership::~Membership() = default;
 
 String Membership::custom_data() const {
-    return this->data->to_custom_data();
+    return this->data->to_membership_data().custom_data_json;
+}
+
+ChatMembershipData Membership::membership_data() const {
+    return this->data->to_membership_data();
 }
 
 Membership Membership::update(const String& custom_object_json) const {
-    return this->membership_service->update(user, channel, custom_object_json);
+    return this->membership_service->update(user, channel, MembershipDAO(ChatMembershipData{custom_object_json, "", ""}));
+}
+
+Membership Membership::update(const Pubnub::ChatMembershipData& membership_data) const {
+    return this->membership_service->update(user, channel, MembershipDAO(membership_data));
 }
 
 String Membership::last_read_message_timetoken() const {

--- a/src/string.cpp
+++ b/src/string.cpp
@@ -425,6 +425,10 @@ String operator+(const String& lhs, const String& rhs) {
 }
 
 bool operator==(const String& lhs, const String& rhs) {
+    if(lhs.c_str() == nullptr && rhs.c_str() == nullptr) {
+        return true;
+    }
+
     if(lhs.c_str() == nullptr || rhs.c_str() == nullptr) {
         return false;
     }
@@ -433,6 +437,13 @@ bool operator==(const String& lhs, const String& rhs) {
 }
 
 bool operator!=(const String& lhs, const String& rhs) {
+    if(lhs.c_str() == nullptr && rhs.c_str() == nullptr) {
+        return false;
+    }
+
+    if(lhs.c_str() == nullptr || rhs.c_str() == nullptr) {
+        return true;
+    }
     return strcmp(lhs.c_str(), rhs.c_str()) != 0;
 }
 

--- a/test/unit/membership_entity_unit.cpp
+++ b/test/unit/membership_entity_unit.cpp
@@ -13,8 +13,8 @@ Ensure(MembershipEntities, should_be_parsed_from_json) {
     auto result = MembershipEntity::from_json(Json::parse("{\"custom\":\"data\",\"status\":\"status\",\"type\":\"type\"}"));
 
     assert_string_equal(result.custom_field.c_str(), "\"data\"");
-    assert_string_equal(sut.status.c_str(), "status");
-    assert_string_equal(sut.type.c_str(), "type");
+    assert_string_equal(result.status.c_str(), "status");
+    assert_string_equal(result.type.c_str(), "type");
 }
 
 Ensure(MembershipEntities, should_update) {

--- a/test/unit/membership_entity_unit.cpp
+++ b/test/unit/membership_entity_unit.cpp
@@ -10,14 +10,16 @@ BeforeEach(MembershipEntities) {/* no setup needed */}
 AfterEach(MembershipEntities) {/* no cleanup needed */}
 
 Ensure(MembershipEntities, should_be_parsed_from_json) {
-    auto result = MembershipEntity::from_json(Json::parse("{\"custom\":\"data\"}"));
+    auto result = MembershipEntity::from_json(Json::parse("{\"custom\":\"data\",\"status\":\"status\",\"type\":\"type\"}"));
 
     assert_string_equal(result.custom_field.c_str(), "\"data\"");
+    assert_string_equal(sut.status.c_str(), "status");
+    assert_string_equal(sut.type.c_str(), "type");
 }
 
 Ensure(MembershipEntities, should_update) {
-    MembershipEntity base {"base"};
-    MembershipEntity update {"update"};
+    MembershipEntity base {"base", "base_status", "base_type"};
+    MembershipEntity update {"update", "update_status", "update_type"};
     MembershipEntity empty_update {""};
 
     auto updated = MembershipEntity::from_base_and_updated_membership(base, update);
@@ -25,4 +27,8 @@ Ensure(MembershipEntities, should_update) {
 
     assert_string_equal(updated.custom_field.c_str(), "update");
     assert_string_equal(empty_updated.custom_field.c_str(), "base");
+    assert_string_equal(updated.status.c_str(), "update_status");
+    assert_string_equal(empty_updated.status.c_str(), "base_status");
+    assert_string_equal(updated.type.c_str(), "update_type");
+    assert_string_equal(empty_updated.type.c_str(), "base_type");
 }

--- a/test/unit/restrictions_unit.cpp
+++ b/test/unit/restrictions_unit.cpp
@@ -15,8 +15,8 @@ Ensure(Restriction, should_prepare_remove_member_payload) {
 }
 
 Ensure(Restriction, should_prepare_lift_restrictions_payload) {
-    auto result = trim_whitespaces(Restrictions::lift_restrictions_payload("channel1", "reason"));
-    assert_string_equal(result.c_str(), "{\"channelId\":\"PUBNUB_INTERNAL_MODERATION_channel1\",\"restrictions\":\"lifted\",\"reason\":\"reason\"}");
+    auto result = trim_whitespaces(Restrictions::lift_restrictions_payload("PUBNUB_INTERNAL_MODERATION_channel1", "reason"));
+    assert_string_equal(result.c_str(), "{\"channelId\":\"PUBNUB_INTERNAL_MODERATION_channel1\",\"restriction\":\"lifted\",\"reason\":\"reason\"}");
 }
 
 Ensure(Restriction, should_prepare_restrict_member_payload) {

--- a/test/unit/typing_unit.cpp
+++ b/test/unit/typing_unit.cpp
@@ -60,36 +60,25 @@ Ensure(Typings, should_return_typing_users) {
 }
 
 Ensure(Typings, should_prepare_payload_for_typing_user) {
-    auto result = trim_whitespaces(Typing::payload("user1", true));
+    auto result = trim_whitespaces(Typing::payload(true));
 
-    assert_false(result.find("\"userId\":\"user1\"") == Pubnub::String::npos);
     assert_false(result.find("\"value\":true") == Pubnub::String::npos);
 }
 
 Ensure(Typings, should_prepare_payload_for_stopped_typing_user) {
-    auto result = trim_whitespaces(Typing::payload("user1", false));
+    auto result = trim_whitespaces(Typing::payload(false));
 
-    assert_false(result.find("\"userId\":\"user1\"") == Pubnub::String::npos);
     assert_false(result.find("\"value\":false") == Pubnub::String::npos);
 }
 
-Ensure(Typings, should_parse_payload_for_user_and_its_typing_state) {
-    auto result = Typing::typing_user_from_payload(Json::parse("{\"userId\":\"user1\",\"value\":true}"));
-
-    assert_true(result.has_value());
-    assert_string_equal(result.value().first.c_str(), "user1");
-    assert_true(result.value().second);
-}
-
-Ensure(Typings, should_parse_event_for_user_and_its_typing_state) {
+Ensure(Typings, should_parse_event_for_typing_state) {
     Pubnub::Event event;
-    event.payload = "{\"userId\":\"user1\",\"value\":true}";
+    event.payload = "{\"value\":true}";
 
-    auto result = Typing::typing_user_from_event(event);
+    auto result = Typing::typing_value_from_event(event);
 
     assert_true(result.has_value());
-    assert_string_equal(result.value().first.c_str(), "user1");
-    assert_true(result.value().second);
+    assert_true(result.value());
 }
 
 


### PR DESCRIPTION
Add `Membership` status and type fields. Now `Membership` has dedicated struct `ChatMembershipData` - the same as `User` and `Channel`.
Fix other failing unit tests.
Fix == and != String operators to return correct values when compared strings are invalid.